### PR TITLE
Add vitest and unit test for calendar-utils

### DIFF
--- a/lib/__tests__/calendar-utils.test.ts
+++ b/lib/__tests__/calendar-utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { getMonthMatrix } from '../calendar-utils'
+
+
+describe('getMonthMatrix', () => {
+  it('returns an array of 42 elements', () => {
+    const matrix = getMonthMatrix(new Date('2024-01-01'))
+    expect(matrix).toHaveLength(42)
+  })
+
+  it('first row is Monday-started', () => {
+    const matrix = getMonthMatrix(new Date('2024-04-01'))
+    const firstRow = matrix.slice(0, 7)
+    const expectedDays = [1,2,3,4,5,6,0] // Mon..Sun
+    firstRow.forEach((d, i) => {
+      if (d) {
+        expect(d.getDay()).toBe(expectedDays[i])
+      }
+    })
+  })
+
+  it('invalid dates return an array of nulls', () => {
+    const matrix = getMonthMatrix(new Date('invalid'))
+    expect(matrix).toHaveLength(42)
+    matrix.forEach(cell => expect(cell).toBeNull())
+  })
+})

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -70,6 +71,7 @@
     "@types/react-dom": "^19.1.6",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^1.5.0"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+})


### PR DESCRIPTION
## Summary
- configure vitest using `vitest.config.ts`
- add `vitest` dev dependency and `test` npm script
- create unit tests for `getMonthMatrix`

## Testing
- `pnpm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a4347e85c83299b3f892d63099b6e